### PR TITLE
Bump the CLI extension version and add multi-tagging

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -260,7 +260,7 @@ function acrBuild(e, project, tag) {
   builder.storage.enabled = true;
   builder.tasks = [
     // When the extension is included by default, we can remove this.
-    "az extension add --source https://acrbuild.blob.core.windows.net/cli/acrbuildext-0.0.2-py2.py3-none-any.whl -y",
+    "az extension add --source https://acrbuild.blob.core.windows.net/cli/acrbuildext-0.0.4-py2.py3-none-any.whl -y",
     // Create a service principal and assign it proper perms on the ACR.
     `az login --service-principal -u ${project.secrets.acrName} -p '${project.secrets.acrToken}' --tenant ${project.secrets.acrTenant}`,
     `cd /src`,
@@ -279,8 +279,7 @@ function acrBuild(e, project, tag) {
       // Total hack to work around something weird with brigade-github-gateway
       `[ ! -f /mnt/brigade/share/${i}/rootfs/${i} ] || cp /mnt/brigade/share/${i}/rootfs/${i} ./rootfs/`,
       // Currently, it appears this is the only way to add two tags.
-      `az acr build -r ${registry} -t ${imgName} --context .`,
-      `az acr build -r ${registry} -t ${latest} --context .`,
+      `az acr build -r ${registry} -t ${imgName} -t ${latest} --context .`,
       `echo '<======== Finished ${i}'`,
       `cd ..`
     );


### PR DESCRIPTION
I didn't actually run this, so be sure to verify it, but it should be good from the CLI's perspective.

You don't have to queue multiple builds anymore. :tada: 